### PR TITLE
feat: Implement dark and light theme switching

### DIFF
--- a/css/estilos.css
+++ b/css/estilos.css
@@ -1,3 +1,21 @@
+.light-mode {
+  --main-bg-gradient-start: #a234a1;
+  --main-bg-gradient-end: #e12345;
+  --main-text-color: white;
+  --main-shadow-color: rgba(0, 0, 0, 0.5);
+  --button-text-color: black;
+  --button-bg-color: #f0f0f0;
+}
+
+.dark-mode {
+  --main-bg-gradient-start: #2c3e50;
+  --main-bg-gradient-end: #1a252f;
+  --main-text-color: #ecf0f1;
+  --main-shadow-color: rgba(255, 255, 255, 0.2);
+  --button-text-color: white;
+  --button-bg-color: #34495e;
+}
+
 body {
   margin: 0px;
   padding: 0px;
@@ -11,14 +29,14 @@ body {
 }
 #contenedor {
   width: 50%;
-  background-image: linear-gradient(#a234a1, #e12345);
+  background-image: linear-gradient(var(--main-bg-gradient-start, #a234a1), var(--main-bg-gradient-end, #e12345)); /* Fallbacks added */
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  color: white;
+  color: var(--main-text-color, white); /* Fallback added */
   padding: 2em;
-  box-shadow: 0px 0px 20px #000;
+  box-shadow: 0px 0px 20px var(--main-shadow-color, rgba(0, 0, 0, 0.5)); /* Fallback added */
 }
 #contenedor img {
   width: 50%;
@@ -34,4 +52,22 @@ body {
   margin-top: 1em;
   font-size: 1.5em;
   cursor: pointer;
+  color: var(--button-text-color, black); /* Fallback added */
+  background-color: var(--button-bg-color, #f0f0f0); /* Fallback added */
+  border: none;
+  padding: 0.5em 1em;
+  border-radius: 5px;
+}
+
+#theme-switcher {
+  padding: 0.5em 1em;
+  border: 1px solid var(--button-text-color, black);
+  background-color: var(--button-bg-color, #f0f0f0);
+  color: var(--button-text-color, black);
+  cursor: pointer;
+  border-radius: 5px;
+  position: fixed;
+  top: 10px;
+  right: 10px;
+  z-index: 1000;
 }

--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
     <div class="card-container">
       <div id="contenedor"></div>
     </div>
+    <button id="theme-switcher">Switch Theme</button>
     <script src="js/data.js"></script>
   </body>
 </html>

--- a/js/data.js
+++ b/js/data.js
@@ -42,3 +42,33 @@ const aleatorio_entre = (min, max) => {
 };
 
 traer_datos(1);
+
+// Theme Switcher Logic
+const themeSwitcherButton = document.getElementById('theme-switcher');
+const bodyElement = document.body;
+
+function applyTheme(theme) {
+  bodyElement.classList.remove('light-mode', 'dark-mode'); // Remove any existing theme class
+  if (theme === 'dark') {
+    bodyElement.classList.add('dark-mode');
+  } else {
+    bodyElement.classList.add('light-mode');
+  }
+}
+
+// Load saved theme or default to light
+let savedTheme = localStorage.getItem('theme');
+if (!savedTheme) {
+  savedTheme = 'light'; // Default to light
+  localStorage.setItem('theme', savedTheme); // Save the default
+}
+applyTheme(savedTheme);
+
+// Event listener for the button
+if (themeSwitcherButton) { // Check if button exists
+  themeSwitcherButton.addEventListener('click', () => {
+    let newTheme = bodyElement.classList.contains('light-mode') ? 'dark' : 'light';
+    applyTheme(newTheme);
+    localStorage.setItem('theme', newTheme);
+  });
+}


### PR DESCRIPTION
This commit introduces a theme switching functionality, allowing you to toggle between a light and a dark mode for the application.

Key changes include:

- **CSS:**
    - Defined CSS variables for themable properties (colors, gradients, shadows).
    - Created `.light-mode` and `.dark-mode` classes in `css/estilos.css` that set these variables.
    - Updated existing styles for `#contenedor` and `#random` button to use these CSS variables.
    - Added styling for the new theme switcher button.

- **HTML:**
    - Added a "Switch Theme" button (`#theme-switcher`) to `index.html` for your interaction.

- **JavaScript:**
    - Implemented logic in `js/data.js` to handle theme switching.
    - On page load, the script checks `localStorage` for a saved theme preference and applies it. If no preference is found, it defaults to light mode and saves this preference.
    - An event listener on the theme switcher button toggles between 'light' and 'dark' themes, updates the `body` class accordingly, and saves the new preference to `localStorage`.

The changes have been reviewed conceptually and appear to function as intended.